### PR TITLE
Delete previous records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .idea/
 coverage/
-public/uploads/*

--- a/features/step_definitions/my_steps.rb
+++ b/features/step_definitions/my_steps.rb
@@ -9,3 +9,7 @@ When(/^I visit '(.*)'$/) do |endpoint|
   url = "http://localhost:9292#{endpoint}"
   visit url
 end
+
+Given(/^there's (\d+) records in the database$/) do |num|
+  create_list(:mediator, num.to_i)
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -8,3 +8,6 @@ Capybara.server_port = 9292
 Capybara.app = Rack::Builder.parse_file(File.expand_path('../../config.ru', __dir__)).first
 
 ActiveRecord::Base.logger = nil # Get rid of Sinatra's noisy logging in tests
+
+require_relative '../../spec/factories/mediator'
+World(FactoryGirl::Syntax::Methods)

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -6,10 +6,10 @@ Feature: Admin app
     When I visit '/api/v1/mediators'
     Then the response data should have 7 items
 
-  Scenario: Replace previous records
-    Given I upload a well-formed spreadsheet
-    And I see 'File uploaded'
-    And I upload a well-formed spreadsheet
-    And I see 'File uploaded'
-    When I visit '/api/v1/mediators'
+  Scenario: Delete previous records
+    Given there's 10 records in the database
+    And I visit '/api/v1/mediators'
+    And the response data should have 10 items
+    When I upload a well-formed spreadsheet
+    And I visit '/api/v1/mediators'
     Then the response data should have 7 items

--- a/features/upload.feature
+++ b/features/upload.feature
@@ -5,3 +5,11 @@ Feature: Admin app
     And I see 'File uploaded'
     When I visit '/api/v1/mediators'
     Then the response data should have 7 items
+
+  Scenario: Replace previous records
+    Given I upload a well-formed spreadsheet
+    And I see 'File uploaded'
+    And I upload a well-formed spreadsheet
+    And I see 'File uploaded'
+    When I visit '/api/v1/mediators'
+    Then the response data should have 7 items

--- a/lib/admin/processing/spreadsheet.rb
+++ b/lib/admin/processing/spreadsheet.rb
@@ -18,6 +18,7 @@ module Admin
       private
 
       def create_mediators
+        mediators = []
         @data.each do |mediator_row|
           row_data = {}
           mediator_row.each_with_index do |value, index|
@@ -27,8 +28,12 @@ module Admin
               row_data[@headings[index]] = value
             end
           end
+          mediators << { data: row_data }
+        end
 
-          API::Models::Mediator.create(data: row_data)
+        ActiveRecord::Base.transaction do
+          API::Models::Mediator.delete_all
+          API::Models::Mediator.create(mediators)
         end
       end
 

--- a/spec/admin/processing/spreadsheet_spec.rb
+++ b/spec/admin/processing/spreadsheet_spec.rb
@@ -1,5 +1,3 @@
-require 'spec_helper'
-
 module Admin
   module Processing
     describe Spreadsheet do


### PR DESCRIPTION
An ActiveRecord transaction wraps the delete_all and creation of new mediator records.

The `Admin::Processing::Spreadsheet` class should be broken up soon.