### PR TITLE
Spreadsheet spec creates workbook via rubyXL DSL

### DIFF
--- a/lib/admin/app.rb
+++ b/lib/admin/app.rb
@@ -28,10 +28,11 @@ module Admin
 
     post '/upload' do
       begin
-        raise "No file specified" unless params[:spreadsheet_file]
-
+        raise 'No file specified' unless params[:spreadsheet_file]
         file = params[:spreadsheet_file][:tempfile]
-        Processing::Spreadsheet.new(file.path, settings.parser).process
+
+        spreadsheet = Processing::Spreadsheet.new(RubyXL::Parser.parse(file.path), settings.parser)
+        spreadsheet.process
 
         redirect to "/upload-success?filesize=#{file.size}"
 

--- a/lib/admin/app.rb
+++ b/lib/admin/app.rb
@@ -36,8 +36,8 @@ module Admin
 
         redirect to "/upload-success?filesize=#{file.size}"
 
-      rescue => e
-        LOGGER.fatal "Failed /upload: #{e.message}"
+      rescue => error
+        LOGGER.fatal "Failed /upload: #{error.message}"
         redirect to '/upload-fail'
       end
     end

--- a/lib/admin/processing/spreadsheet.rb
+++ b/lib/admin/processing/spreadsheet.rb
@@ -11,8 +11,7 @@ module Admin
       end
 
       def process
-        data = to_h
-        # validate - this will come later
+        data = to_hash
         data = parser.parse(data) if parser
         save(data)
       end
@@ -28,7 +27,7 @@ module Admin
         end
       end
 
-      def to_h
+      def to_hash
         processed_headings = Headings.process(first_worksheet[0].cells.map { |cell| cell.value })
 
         first_worksheet[1..-1].map do |row|

--- a/lib/admin/processing/spreadsheet.rb
+++ b/lib/admin/processing/spreadsheet.rb
@@ -5,13 +5,13 @@ module Admin
 
       attr_reader :parser
 
-      def initialize(file_path, parser = nil)
-        @file_path = file_path
+      def initialize(workbook, parser = nil)
+        @workbook = workbook
         @parser = parser
       end
 
       def process
-        data = extract_data
+        data = to_h
         # validate - this will come later
         data = parser.parse(data) if parser
         save(data)
@@ -28,20 +28,18 @@ module Admin
         end
       end
 
-      def extract_data
-        raise "File not found: #{@file_path}" unless File.exist?(@file_path)
+      def to_h
+        processed_headings = Headings.process(first_worksheet[0].cells.map { |cell| cell.value })
 
-        headings = Headings.process(workbook.delete_row(0).cells.map {|cell| cell.value})
-
-        workbook.map do |row|
+        first_worksheet[1..-1].map do |row|
           row.cells.each_with_index.inject({}) do |hash, (cell, index)|
-            hash.merge({ headings[index] => cell.value.to_s })
+            hash.merge({ processed_headings[index] => cell.value.to_s })
           end
         end
       end
 
-      def workbook
-        @workbook ||= RubyXL::Parser.parse(@file_path)[0]
+      def first_worksheet
+        @workbook[0]
       end
 
     end

--- a/spec/admin/processing/spreadsheet_spec.rb
+++ b/spec/admin/processing/spreadsheet_spec.rb
@@ -2,18 +2,6 @@ module Admin
   module Processing
     describe Spreadsheet do
 
-      # let(:filepath) do
-      #   File.expand_path('../../../support/fixtures/spreadsheet.xlsx', __FILE__)
-      # end
-      #
-      # let(:expected_data) do
-      #   [
-      #     {"month_number"=>"1.0", "month_name"=>"January"},
-      #     {"month_number"=>"2.0", "month_name"=>"February"},
-      #     {"month_number"=>"3.0", "month_name"=>"March"}
-      #   ]
-      # end
-
       let(:workbook) do
         workbook = RubyXL::Workbook.new
         worksheet = workbook[0]
@@ -34,7 +22,6 @@ module Admin
       end
 
       before do
-        # allow(RubyXL::Parser).to receive(:parse).and_return([workbook])
         allow(API::Models::Mediator).to receive(:create)
       end
 
@@ -44,12 +31,8 @@ module Admin
 
       context '#extract_data' do
         it 'Transforms data' do
-          expect(subject.send(:to_h)).to eq(expected_data)
+          expect(subject.send(:to_hash)).to eq(expected_data)
         end
-      end
-
-      it 'should process headings' do
-        subject.process
       end
 
       it 'should insert into DB' do

--- a/spec/admin/processing/spreadsheet_spec.rb
+++ b/spec/admin/processing/spreadsheet_spec.rb
@@ -2,15 +2,34 @@ module Admin
   module Processing
     describe Spreadsheet do
 
-      let(:filepath) do
-        File.expand_path('../../../support/fixtures/spreadsheet.xlsx', __FILE__)
+      # let(:filepath) do
+      #   File.expand_path('../../../support/fixtures/spreadsheet.xlsx', __FILE__)
+      # end
+      #
+      # let(:expected_data) do
+      #   [
+      #     {"month_number"=>"1.0", "month_name"=>"January"},
+      #     {"month_number"=>"2.0", "month_name"=>"February"},
+      #     {"month_number"=>"3.0", "month_name"=>"March"}
+      #   ]
+      # end
+
+      let(:workbook) do
+        workbook = RubyXL::Workbook.new
+        worksheet = workbook[0]
+        worksheet.add_cell(0,0, 'First Name')
+        worksheet.add_cell(0,1, 'Last Name')
+        worksheet.add_cell(1,0, 'John')
+        worksheet.add_cell(1,1, 'Smith')
+        worksheet.add_cell(2,0, 'Donna')
+        worksheet.add_cell(2,1, 'Jones')
+        workbook
       end
 
       let(:expected_data) do
         [
-          {"month_number"=>"1.0", "month_name"=>"January"},
-          {"month_number"=>"2.0", "month_name"=>"February"},
-          {"month_number"=>"3.0", "month_name"=>"March"}
+          {'first_name' => 'John', 'last_name' => 'Smith'},
+          {'first_name' => 'Donna', 'last_name' => 'Jones'}
         ]
       end
 
@@ -20,12 +39,12 @@ module Admin
       end
 
       subject do
-        Admin::Processing::Spreadsheet.new(filepath)
+        Admin::Processing::Spreadsheet.new(workbook)
       end
 
       context '#extract_data' do
         it 'Transforms data' do
-          expect(subject.send(:extract_data)).to eq(expected_data)
+          expect(subject.send(:to_h)).to eq(expected_data)
         end
       end
 


### PR DESCRIPTION
 - Spreadsheet class expects RubyXL object to be passed in, meaning caller responsible for reading/creating file
 - renamed extract_data to to_h
 - extracting headers no longer a destructive action, original data left intact