### PR TITLE
Check for null values in cells

### DIFF
--- a/lib/admin/parsers/workbook.rb
+++ b/lib/admin/parsers/workbook.rb
@@ -29,7 +29,8 @@ module Admin
 
         worksheet[1..-1].map do |row|
           row.cells.each_with_index.inject({}) do |hash, (cell, index)|
-            hash.merge({processed_headings[index].to_sym => cell.value.to_s})
+            value = cell && cell.value
+            hash.merge({processed_headings[index].to_sym => value.to_s})
           end
         end
       end

--- a/spec/admin/parsers/workbook_spec.rb
+++ b/spec/admin/parsers/workbook_spec.rb
@@ -2,27 +2,48 @@ module Admin
   module Parsers
     describe Workbook do
 
-      let(:rubyxl_workbook) do
-        headings = ['First Name', 'Last Name']
-        data = [%w{ John Smith }, %w{ Donna Jones }]
-        Support::Factories::Spreadsheet.build(headings, data)
-      end
-
-      let(:expected_data) do
-        [
-          {:first_name => 'John', :last_name => 'Smith'},
-          {:first_name => 'Donna', :last_name => 'Jones'}
-        ]
-      end
-
       subject do
         Workbook.new(rubyxl_workbook)
       end
 
       context '#transform_worksheet' do
+
+        let(:rubyxl_workbook) do
+          headings = ['First Name', 'Last Name']
+          data = [%w{ John Smith }, %w{ Donna Jones }]
+          Support::Factories::Spreadsheet.build(headings, data)
+        end
+
+        let(:expected_data) do
+          [
+              {:first_name => 'John', :last_name => 'Smith'},
+              {:first_name => 'Donna', :last_name => 'Jones'}
+          ]
+        end
+
         it 'Transforms data' do
           expect(subject.send(:transform_worksheet)).to eq(expected_data)
         end
+
+        context 'with null values for blank cells' do
+          let(:rubyxl_workbook) do
+            headings = ['First Name', 'Last Name']
+            data = [%w{ John Smith }, [nil, 'Baker'], %w{ Donna Jones }]
+            Support::Factories::Spreadsheet.build(headings, data)
+          end
+          let(:expected_data) do
+            [
+                {:first_name => 'John', :last_name => 'Smith'},
+                {:first_name => '', :last_name => 'Baker'},
+                {:first_name => 'Donna', :last_name => 'Jones'}
+            ]
+          end
+
+          it 'Transforms data' do
+            expect(subject.send(:transform_worksheet)).to eq(expected_data)
+          end
+        end
+
       end
 
       context 'empty workbook' do
@@ -38,6 +59,8 @@ module Admin
           end
         end
       end
+
+
 
     end
   end


### PR DESCRIPTION
Some blank cells in OOXML file formats return an empty string, while others blank cells return null. See http://blog.softartisans.com/2013/12/30/kb-why-do-some-blank-cells-return-different-values-in-ooxml/