### PR TITLE
Update CircleCI to work with Live-1 k8s cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
       - run:
           name: push docker image
           command: |
-            login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
+            login="$(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)"
             ${login}
 
             docker tag app "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
@@ -109,7 +109,7 @@ jobs:
 
             kubectl set image -n family-mediators-api-staging \
                     deployment/family-mediators-api-deployment-staging \
-                    family-mediators-api-web-staging="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
+                    webapp="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
 
             kubectl annotate -n family-mediators-api-staging \
                     deployment/family-mediators-api-deployment-staging \
@@ -126,7 +126,7 @@ jobs:
       - run:
           name: promote staging image to production
           command: |
-            login="$(aws ecr get-login --region eu-west-1 --no-include-email)"
+            login="$(aws ecr get-login --region ${AWS_DEFAULT_REGION} --no-include-email)"
             ${login}
 
             docker pull "${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
@@ -155,7 +155,7 @@ jobs:
 
             kubectl set image -n family-mediators-api-production \
                     deployment/family-mediators-api-deployment-production \
-                    family-mediators-api-web-production="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
+                    webapp="${ECR_ENDPOINT}/${GITHUB_TEAM_NAME_SLUG}/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}"
 
             kubectl annotate -n family-mediators-api-production \
                     deployment/family-mediators-api-deployment-production \


### PR DESCRIPTION
We had hardcoded the AWS region, and in live-1 this has to change from eu-west-1 to eu-west-2. So better to use the ENV variable already exposed.

Also, for consistency, we are going to name the container in all our applications the same (webapp) as it makes it easier to work with when there are multiple containers (like another one running nginx).