### PR TITLE
Stop using ministryofjustice/docker-templates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ version: '3'
 services:
   db:
     image: postgres
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
+
   web:
     build: .
     environment:

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 cd /usr/src/app
 
 bundle exec rake db:create db:migrate db:seed


### PR DESCRIPTION
The Dockerfiles in the repo docker-templates [1] is being deprecated and it is recommended to keep Dockerfiles and docker images as lightweight and simple as possible.

In this case we are going to refactor the Dockerfile to use an alpine image and add dependencies on top.

[1] https://github.com/ministryofjustice/docker-templates