### PR TITLE
Add headings memoization optimisation

### DIFF
--- a/lib/admin/parsers/workbook.rb
+++ b/lib/admin/parsers/workbook.rb
@@ -52,15 +52,15 @@ module Admin
         mediators_worksheet[1..-1].map.with_index do |row|
           processed_headings.size.times.inject({}) do |hash, index|
             cell = row.cells[index]
-            value = cell && cell.value
+            value = cell&.value
             hash.merge({processed_headings[index].to_sym => value})
           end
         end
       end
 
       def processed_headings
-        @headings_processor.process(
-          mediators_worksheet[0].cells.map { |cell| cell.value }
+        @_processed_headings ||= @headings_processor.process(
+          mediators_worksheet[0].cells.map(&:value)
         )
       end
 
@@ -71,7 +71,6 @@ module Admin
       def blacklist_worksheet
         @rubyxl_workbook[BLACKLIST_WORKSHEET] if @rubyxl_workbook
       end
-
     end
   end
 end


### PR DESCRIPTION
Incidentally as part of the refactor for the validations in PR #106, as I had to run many many tests and many uploads as well, I found the main cause of the veeeery slow file processing times.

The `#processed_headings` method was being called (in the `#transform_mediators` loop) more than 1k times, 1 for each row in the file, and each time it was called it performed the exact same operations on the exact same data, meaning it was a candidate for memoization.

Benchmark results before and after memoization for the exact same file and number of rows (1103):

Before:
```
44.086576   0.220200  44.306776 ( 44.318976)
```

After:
```
0.753861   0.043804   0.797665 (  0.797686)
```