### PR TITLE
Stop using `circleci` branch of cloud-platform/tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,10 @@ references:
           POSTGRES_DB: mediators_ci_test
   cloud_container: &cloud_container
     docker:
-      - image: ${ECR_ENDPOINT}/cloud-platform/tools:circleci
+      - image: ministryofjustice/cloud-platform-tools:1.24
         environment:
           GITHUB_TEAM_NAME_SLUG: family-justice
+          REPO_NAME: family-mediators-api
 
 
 jobs:


### PR DESCRIPTION
As per conversation here:
https://mojdt.slack.com/archives/CH6D099DF/p1601893835012800

`circleci` is no longer maintained and is recommended to use the main branch on the tools repo.