### PR TITLE
Cdpt 767 migrate to short lived credentials

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -48,7 +48,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: test
-
+    if: github.ref == 'refs/heads/main'
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: read  # This is required for actions/checkout
@@ -118,15 +118,12 @@ jobs:
   deploy-production:
     runs-on: ubuntu-latest
     needs: deploy-staging
-
-    if: github.ref == 'refs/heads/main'
     environment: production
 
     env:
       KUBE_NAMESPACE: ${{ secrets.KUBE_PROD_NAMESPACE }}
 
     steps:
-
       - name: Authenticate to the cluster
         env:
           KUBE_CERT: ${{ secrets.KUBE_PROD_CERT }}

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -48,11 +48,24 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: test
-    if: github.ref == 'refs/heads/main'
+
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: read  # This is required for actions/checkout
 
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
+      - name: Assume role in Cloud Platform
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.ECR_ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.ECR_REGION }}
+
+      - name: Login to container repository
+        uses: aws-actions/amazon-ecr-login@v1
+        id: login-ecr
 
       - name: Store current date
         run: echo "BUILD_DATE=$(date +%Y%m%d%H%M)" >> $GITHUB_ENV
@@ -66,17 +79,11 @@ jobs:
             --build-arg BUILD_DATE=${{ env.BUILD_DATE }} \
             --build-arg BUILD_TAG=${{ github.ref }} \
             --build-arg GIT_COMMIT=${{ github.sha }} \
-            -t app .
+            -t ${{ vars.ECR_URL }}:${{ github.sha }} .
 
       - name: Push to ECR
-        id: ecr
-        uses: jwalton/gh-ecr-push@v1.3.3
-        with:
-          access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
-          region: eu-west-2
-          local-image: app
-          image: ${{ secrets.ECR_NAME }}:${{ github.sha }}, ${{ secrets.ECR_NAME }}:staging.latest
+        run: |
+          docker push ${{ vars.ECR_URL }}:${{ github.sha }}
 
   deploy-staging:
     runs-on: ubuntu-latest
@@ -102,37 +109,19 @@ jobs:
         run: |
           kubectl set image -n ${KUBE_NAMESPACE} \
           deployment/family-mediators-api-deployment-staging \
-          webapp="${{ secrets.ECR_URL }}:${{ github.sha }}"
+          webapp="${{ vars.ECR_URL }}:${{ github.sha }}"
 
   deploy-production:
     runs-on: ubuntu-latest
     needs: deploy-staging
+
+    if: github.ref == 'refs/heads/main'
     environment: production
 
     env:
       KUBE_NAMESPACE: ${{ secrets.KUBE_PROD_NAMESPACE }}
 
     steps:
-      - name: Pull from ECR
-        id: ecr-pull
-        uses: jwalton/gh-ecr-push@v1.3.3
-        with:
-          access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
-          region: eu-west-2
-          direction: pull
-          local-image: app
-          image: ${{ secrets.ECR_NAME }}:${{ github.sha }}
-
-      - name: Push to ECR
-        id: ecr-push
-        uses: jwalton/gh-ecr-push@v1.3.3
-        with:
-          access-key-id: ${{ secrets.ECR_AWS_ACCESS_KEY_ID }}
-          secret-access-key: ${{ secrets.ECR_AWS_SECRET_ACCESS_KEY }}
-          region: eu-west-2
-          local-image: app
-          image: ${{ secrets.ECR_NAME }}:production.latest
 
       - name: Authenticate to the cluster
         env:
@@ -150,4 +139,4 @@ jobs:
         run: |
           kubectl set image -n ${KUBE_NAMESPACE} \
           deployment/family-mediators-api-deployment-production \
-          webapp="${{ secrets.ECR_URL }}:${{ github.sha }}"
+          webapp="${{ vars.ECR_URL }}:${{ github.sha }}"

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -83,7 +83,11 @@ jobs:
 
       - name: Push to ECR
         run: |
+          docker tag ${{ vars.ECR_URL }}:${{ github.sha }} ${{ vars.ECR_URL }}:staging.latest
+          docker tag ${{ vars.ECR_URL }}:${{ github.sha }} ${{ vars.ECR_URL }}:production.latest
           docker push ${{ vars.ECR_URL }}:${{ github.sha }}
+          docker push ${{ vars.ECR_URL }}:staging.latest
+          docker push ${{ vars.ECR_URL }}:production.latest
 
   deploy-staging:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As per general guidance from https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/container-repositories/deprecating-long-lived-credentials.html#deprecating-long-lived-credentials-for-container-repositories