### PR TITLE
Cdpt 874 add brakeman to GitHub actions pipeline

### DIFF
--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -49,6 +49,7 @@ jobs:
           # --force required as no /app dir as expected
           # https://github.com/presidentbeef/brakeman/issues/67#issuecomment-4947358
           brakeman_flags: --force
+          reporter: github-pr-review
 
       - name: Run linters and tests
         run: bundle exec rake

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -46,6 +46,7 @@ jobs:
         uses: reviewdog/action-brakeman@v2
         with:
           brakeman_version: 5.4.1
+          workdir: /
 
       - name: Run linters and tests
         run: bundle exec rake

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Brakeman
         uses: reviewdog/action-brakeman@v2
         with:
-          brakeman_version: 5.4.1
+          brakeman_version: gemfile
           # --force required as no /app dir as expected
           # https://github.com/presidentbeef/brakeman/issues/67#issuecomment-4947358
           brakeman_flags: --force

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -43,7 +43,7 @@ jobs:
           bundle exec rake db:schema:load
 
       - name: Run brakeman
-        uses: devmasx/brakeman-linter-action@v1.0.0
+        uses: bundle exec brakeman
 
       - name: Run linters and tests
         run: bundle exec rake

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -42,8 +42,10 @@ jobs:
           bundle exec rake db:create
           bundle exec rake db:schema:load
 
-      - name: Run brakeman
-        run: bundle exec brakeman --force
+      - name: brakeman
+        uses: reviewdog/action-brakeman@v2
+        with:
+          brakeman_version: 5.4.1
 
       - name: Run linters and tests
         run: bundle exec rake
@@ -59,9 +61,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Run brakeman
-        uses: devmasx/brakeman-linter-action@v1.0.0
 
       - name: Assume role in Cloud Platform
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -49,7 +49,6 @@ jobs:
           # --force required as no /app dir as expected
           # https://github.com/presidentbeef/brakeman/issues/67#issuecomment-4947358
           brakeman_flags: --force
-          reporter: github-pr-review
 
       - name: Run linters and tests
         run: bundle exec rake

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -43,7 +43,7 @@ jobs:
           bundle exec rake db:schema:load
 
       - name: Run brakeman
-        run: bundle exec brakeman -f
+        run: bundle exec brakeman --force
 
       - name: Run linters and tests
         run: bundle exec rake

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -43,7 +43,7 @@ jobs:
           bundle exec rake db:schema:load
 
       - name: Run brakeman
-        run: bundle exec brakeman
+        uses: nhattan/brakeman-linter-action@v2.0.0
 
       - name: Run linters and tests
         run: bundle exec rake

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -46,6 +46,8 @@ jobs:
         uses: reviewdog/action-brakeman@v2
         with:
           brakeman_version: 5.4.1
+          # --force required as no /app dir as expected
+          # https://github.com/presidentbeef/brakeman/issues/67#issuecomment-4947358
           brakeman_flags: --force
 
       - name: Run linters and tests

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Run brakeman
+        uses: devmasx/brakeman-linter-action@v1.0.0
+
       - name: Assume role in Cloud Platform
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -43,7 +43,7 @@ jobs:
           bundle exec rake db:schema:load
 
       - name: Run brakeman
-        uses: nhattan/brakeman-linter-action@v2.0.0
+        run: bundle exec brakeman -f
 
       - name: Run linters and tests
         run: bundle exec rake

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -42,6 +42,9 @@ jobs:
           bundle exec rake db:create
           bundle exec rake db:schema:load
 
+      - name: Run brakeman
+        uses: devmasx/brakeman-linter-action@v1.0.0
+
       - name: Run linters and tests
         run: bundle exec rake
 

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -43,7 +43,7 @@ jobs:
           bundle exec rake db:schema:load
 
       - name: Run brakeman
-        uses: bundle exec brakeman
+        run: bundle exec brakeman
 
       - name: Run linters and tests
         run: bundle exec rake

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -42,7 +42,7 @@ jobs:
           bundle exec rake db:create
           bundle exec rake db:schema:load
 
-      - name: brakeman
+      - name: Brakeman
         uses: reviewdog/action-brakeman@v2
         with:
           brakeman_version: 5.4.1

--- a/.github/workflows/test-build-deploy.yml
+++ b/.github/workflows/test-build-deploy.yml
@@ -46,7 +46,7 @@ jobs:
         uses: reviewdog/action-brakeman@v2
         with:
           brakeman_version: 5.4.1
-          workdir: /
+          brakeman_flags: --force
 
       - name: Run linters and tests
         run: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -32,3 +32,7 @@ group :test do
   gem 'rubocop-rails', '~> 2.19', '>= 2.19.1', require: false
   gem 'simplecov', require: false
 end
+
+group :test, :development do
+  gem 'brakeman'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
     ast (2.4.2)
     backports (3.23.0)
     bcrypt (3.1.18)
+    brakeman (5.4.1)
     builder (3.2.4)
     capybara (3.37.1)
       addressable
@@ -236,6 +237,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (< 7.0.0)
   bcrypt
+  brakeman
   cucumber (< 4.0.0)
   database_cleaner
   debug (~> 1.8)

--- a/lib/api/models/mediator.rb
+++ b/lib/api/models/mediator.rb
@@ -6,7 +6,6 @@ module API
       before_create :set_urn_prefix
 
       def set_urn_prefix
-        open(params[:path_or_url])
         self.urn_prefix = data['urn'].to_i
       end
     end

--- a/lib/api/models/mediator.rb
+++ b/lib/api/models/mediator.rb
@@ -6,6 +6,7 @@ module API
       before_create :set_urn_prefix
 
       def set_urn_prefix
+        test
         self.urn_prefix = data['urn'].to_i
       end
     end

--- a/lib/api/models/mediator.rb
+++ b/lib/api/models/mediator.rb
@@ -6,7 +6,7 @@ module API
       before_create :set_urn_prefix
 
       def set_urn_prefix
-        test
+        open(params[:path_or_url])
         self.urn_prefix = data['urn'].to_i
       end
     end


### PR DESCRIPTION
As per Jira ticket: https://dsdmoj.atlassian.net/jira/software/c/projects/CDPT/boards/1152?modal=detail&selectedIssue=CDPT-874

Add brakeman static vulnerability checker to github actions pipeline

Reviewdog example:
<img width="2455" alt="Screenshot 2023-08-29 at 15 46 33" src="https://github.com/ministryofjustice/family-mediators-api/assets/129938801/edfce55f-407f-4318-b572-9cd98ea9df4b">
