### PR TITLE
Fix env vars on ping page

### DIFF
--- a/lib/root_app.rb
+++ b/lib/root_app.rb
@@ -1,8 +1,8 @@
 class RootApp < Sinatra::Base
   BUILD_ARGS = {
-    build_date: ENV["BUILD_DATE"],
-    build_tag: ENV["BUILD_TAG"],
-    commit_id: ENV["GIT_COMMIT"],
+    build_date: ENV["APP_BUILD_DATE"],
+    build_tag: ENV["APP_BUILD_TAG"],
+    commit_id: ENV["APP_GIT_COMMIT"],
   }.freeze
 
   set :public_folder, "public"


### PR DESCRIPTION
The env vars used on the page to show the current deployed version have changed.