### PR TITLE
CDPT-1952 Enable modsec detection mode on production

### DIFF
--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -1,10 +1,10 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: family-mediators-api-ingress-production
+  name: family-mediators-api-ingress-modsec-production
   namespace: family-mediators-api-production
   annotations:
-    external-dns.alpha.kubernetes.io/set-identifier: family-mediators-api-ingress-production-family-mediators-api-production-green
+    external-dns.alpha.kubernetes.io/set-identifier: family-mediators-api-ingress-modsec-production-family-mediators-api-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |

--- a/config/kubernetes/production/ingress.yml
+++ b/config/kubernetes/production/ingress.yml
@@ -6,13 +6,18 @@ metadata:
   annotations:
     external-dns.alpha.kubernetes.io/set-identifier: family-mediators-api-ingress-production-family-mediators-api-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecAuditEngine On
+      SecRuleEngine DetectionOnly
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=family-mediators-api-production"
     nginx.ingress.kubernetes.io/server-snippet: |
       location = /.well-known/security.txt {
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
       }
       location ~* \.(php|cgi|xml)$ { deny all; access_log off; }
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   tls:
   - hosts:
     - family-mediators-api-production.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
## Description
Enables [modsec](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html) in detection mode on production so we can be aware of any issues and evaluate if more protection is required.