### PR TITLE
CDPT-1958 Enable modsec in non-prod namespaces

### DIFF
--- a/config/kubernetes/staging/ingress.yml
+++ b/config/kubernetes/staging/ingress.yml
@@ -11,8 +11,12 @@ metadata:
         return 301 https://raw.githubusercontent.com/ministryofjustice/security-guidance/main/contact/vulnerability-disclosure-security.txt;
       }
       location ~* \.(php|cgi|xml)$ { deny all; access_log off; }
+    nginx.ingress.kubernetes.io/enable-modsecurity: "true"
+    nginx.ingress.kubernetes.io/modsecurity-snippet: |
+      SecRuleEngine On
+      SecDefaultAction "phase:2,pass,log,tag:github_team=central-digital-product-team,tag:namespace=family-mediators-api-staging"
 spec:
-  ingressClassName: default
+  ingressClassName: modsec
   tls:
   - hosts:
     - family-mediators-api-staging.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
## Description
[Modsec](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/modsecurity.html) will stop malicious traffic going to the service.