### PR TITLE
CDPTKAN-1223 set force_ssl / Secure Cookie explicitly

### DIFF
--- a/lib/admin/app.rb
+++ b/lib/admin/app.rb
@@ -1,12 +1,19 @@
 require "sinatra/json"
 require "securerandom"
+require "rack/protection/content_security_policy"
 
 module Admin
   class App < Sinatra::Base
+    use Rack::Protection::ContentSecurityPolicy,
+        default_src: "'self'",
+        form_action: "'self'",
+        frame_ancestors: "'none'"
+
     use Rack::Session::Cookie,
         key: "_fma_session",
         expire_after: 600, # 10 minutes
-        secret: ENV.fetch("SESSION_SECRET") { SecureRandom.hex(64) }
+        secret: ENV.fetch("SESSION_SECRET") { SecureRandom.hex(64) },
+        secure: Sinatra::Base.environment == :production
 
     helpers Helpers
 


### PR DESCRIPTION
Ticket: https://dsdmoj.atlassian.net/browse/CDPTKAN-1223

- Add `secure: true` to the `_fma_session` cookie so browsers are instructed to transmit it over HTTPS only. TLS is terminated at the k8s ingress so the app sees plain HTTP, but without this flag the browser has no instruction to enforce HTTPS-only transmission of the cookie.

- Add Rack::Protection::ContentSecurityPolicy middleware to the Admin app with a restrictive policy. The admin views load only same-origin CSS and images with no JavaScript, so no allowlisting of external sources is needed. `frame-ancestors 'none' `also prevents clickjacking.