### PR TITLE
CDPTKAN-1221 Switch on Content Security Policy

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -20,6 +20,9 @@ use Sentry::Rack::CaptureExceptions
 require "prometheus_middleware"
 use PrometheusMiddleware
 
+require "content_security_policy"
+use ContentSecurityPolicy
+
 require 'lib/env'
 require 'lib/root_app'
 require 'lib/mediators'

--- a/lib/content_security_policy.rb
+++ b/lib/content_security_policy.rb
@@ -1,0 +1,20 @@
+class ContentSecurityPolicy
+  POLICY = [
+    "default-src 'self'",
+    "script-src 'none'",
+    "object-src 'none'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "base-uri 'self'",
+  ].join("; ").freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, body = @app.call(env)
+    headers["Content-Security-Policy"] = POLICY
+    [status, headers, body]
+  end
+end

--- a/spec/content_security_policy_spec.rb
+++ b/spec/content_security_policy_spec.rb
@@ -1,0 +1,46 @@
+require "content_security_policy"
+
+describe ContentSecurityPolicy do
+  include Rack::Test::Methods
+
+  let(:inner_app) { ->(_env) { [200, {}, %w[OK]] } }
+
+  def app
+    ContentSecurityPolicy.new(inner_app)
+  end
+
+  before { get "/" }
+
+  it "sets the Content-Security-Policy header" do
+    expect(last_response.headers["Content-Security-Policy"]).to eq(ContentSecurityPolicy::POLICY)
+  end
+
+  it "includes default-src 'self'" do
+    expect(last_response.headers["Content-Security-Policy"]).to include("default-src 'self'")
+  end
+
+  it "blocks scripts" do
+    expect(last_response.headers["Content-Security-Policy"]).to include("script-src 'none'")
+  end
+
+  it "blocks object embeds" do
+    expect(last_response.headers["Content-Security-Policy"]).to include("object-src 'none'")
+  end
+
+  it "restricts form actions to self" do
+    expect(last_response.headers["Content-Security-Policy"]).to include("form-action 'self'")
+  end
+
+  it "prevents framing" do
+    expect(last_response.headers["Content-Security-Policy"]).to include("frame-ancestors 'none'")
+  end
+
+  it "restricts base URI to self" do
+    expect(last_response.headers["Content-Security-Policy"]).to include("base-uri 'self'")
+  end
+
+  it "passes the response through unchanged" do
+    expect(last_response.status).to eq(200)
+    expect(last_response.body).to eq("OK")
+  end
+end


### PR DESCRIPTION
Ticket:  https://dsdmoj.atlassian.net/browse/CDPTKAN-1221
 - Add ContentSecurityPolicy Rack middleware (lib/content_security_policy.rb) that sets a Content-Security-Policy response header on every request
 - Wire the middleware into config.ru so it applies globally across all mounted apps (RootApp, Admin::App, Documentation::App, API::App
 - Add unit specs covering each CSP directive and middleware passthrough behaviour     