### PR TITLE
  CDPTKAN-1263 Show record count on upload success page and logs

### DIFF
--- a/lib/admin/app.rb
+++ b/lib/admin/app.rb
@@ -86,23 +86,35 @@ module Admin
 
     post "/upload-process" do
       authenticate!
-      success, details = Services::ProcessData.new(params[:dump]).call
+      begin
+        success, details = Services::ProcessData.new(params[:dump]).call
 
-      if success
-        redirect to("/upload-success")
-      else
-        slim :data_errors, locals: details
+        if success
+          session[:upload_count] = details[:count]
+          redirect to("/upload-success")
+        else
+          slim :data_errors, locals: details
+        end
+      rescue StandardError => e
+        LOGGER.fatal "Failed /upload-process: #{e.message}"
+        redirect to("/upload-fail")
       end
     end
 
     get "/upload-success" do
       authenticate!
-      slim :upload_success
+      count = session.delete(:upload_count)
+      slim :upload_success, locals: { uploaded_count: count }
     end
 
     get "/upload-fail" do
       authenticate!
       slim :upload_fail
+    end
+
+    error Rack::Multipart::EmptyContentError do
+      LOGGER.warn "Empty or truncated multipart upload body"
+      redirect to("/upload-fail")
     end
   end
 end

--- a/lib/admin/processing/data_store.rb
+++ b/lib/admin/processing/data_store.rb
@@ -2,10 +2,12 @@ module Admin
   module Processing
     class DataStore
       def self.save(hashes)
-        ActiveRecord::Base.transaction do
+        count = ActiveRecord::Base.transaction do
           API::Models::Mediator.delete_all
-          API::Models::Mediator.create(with_data_attributes(hashes))
+          API::Models::Mediator.create(with_data_attributes(hashes)).size
         end
+        LOGGER.info "Upload complete: #{count} mediator records written to database"
+        count
       end
 
       # Each record has a 'data' attribute which stores the spreadsheet

--- a/lib/admin/services/process_data.rb
+++ b/lib/admin/services/process_data.rb
@@ -19,8 +19,8 @@ module Admin
         data_validations = @data_validator.new(with_expanded_practices)
 
         if data_validations.valid?
-          @data_store.save(with_expanded_practices)
-          [true, {}]
+          count = @data_store.save(with_expanded_practices)
+          [true, { count: count }]
         else
           [false, invalid_locals(data_validations)]
         end

--- a/spec/admin/processing/data_store_spec.rb
+++ b/spec/admin/processing/data_store_spec.rb
@@ -9,12 +9,18 @@ module Admin
       end
 
       before do
-        allow(API::Models::Mediator).to receive(:create)
+        allow(API::Models::Mediator).to receive(:create).and_return([])
       end
 
       it "inserts into DB" do
-        expect(API::Models::Mediator).to receive(:create).once
+        expect(API::Models::Mediator).to receive(:create).once.and_return([])
         described_class.save(data)
+      end
+
+      it "returns the count of records written" do
+        created = [double, double]
+        allow(API::Models::Mediator).to receive(:create).and_return(created)
+        expect(described_class.save(data)).to eq(2)
       end
     end
   end

--- a/spec/admin/processing/data_store_spec.rb
+++ b/spec/admin/processing/data_store_spec.rb
@@ -22,6 +22,11 @@ module Admin
         allow(API::Models::Mediator).to receive(:create).and_return(created)
         expect(described_class.save(data)).to eq(2)
       end
+
+      it "returns zero when no records are written" do
+        allow(API::Models::Mediator).to receive(:create).and_return([])
+        expect(described_class.save([])).to eq(0)
+      end
     end
   end
 end

--- a/views/upload_success.slim
+++ b/views/upload_success.slim
@@ -4,6 +4,9 @@
       h1.bold-large Spreadsheet upload complete
       p
         | Thank you
+      - if uploaded_count
+        p
+          strong = "#{uploaded_count} records successfully written to the database."
 
     p We have processed the spreadsheet data and updated the data served by the Family Mediators API.
     p


### PR DESCRIPTION
  - The upload success page previously showed no indication of how many records were written to the database                                                           
  - `DataStore.save` now returns the record count and logs it at INFO level (`Upload complete: N mediator records written to database`)                                
  - The count is threaded back through `ProcessData` and stored briefly in the session before the post-redirect-get to `/upload-success`                               
  - The success page now displays "N records successfully written to the database." in the confirmation box